### PR TITLE
fix: delete predeploy, add github bot credentials

### DIFF
--- a/.github/workflows/deploy-develop-spa.yml
+++ b/.github/workflows/deploy-develop-spa.yml
@@ -32,6 +32,11 @@ jobs:
           cd dist
           cp index.html 404.html
 
+      - name: Configure Git identity (fixes gh-pages commit error)
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Deploy to GitHub Pages
         run: npm run deploy
         env:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint \"./src/**/*.{js,jsx,ts,tsx}\" --fix",


### PR DESCRIPTION
#### Issue: https://github.com/Blshop/JS-Practice-Hub/issues/14

1. Deleted predeploy
2. Added github bot credentials