### PR TITLE
test: base components tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -17,7 +17,12 @@ module.exports = {
     '\\.(css|scss)$': '<rootDir>/__mocks__/styleMock.js',
   },
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.test.json',
+      },
+    ],
   },
   testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
   collectCoverageFrom: [

--- a/src/components/Button/__tests__/Button.test.tsx
+++ b/src/components/Button/__tests__/Button.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Button from '../Button';
+
+describe('Button Component', () => {
+  describe('Рендеринг', () => {
+    it('рендерит текст кнопки', () => {
+      render(<Button>Click me</Button>);
+      expect(screen.getByText('Click me')).toBeInTheDocument();
+    });
+
+    it('применяет variant класс', () => {
+      render(<Button variant="danger">Delete</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('danger');
+    });
+
+    it('применяет size класс', () => {
+      render(<Button size="large">Big Button</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('large');
+    });
+  });
+
+  describe('Состояния', () => {
+    it('отключается при loading', () => {
+      render(<Button loading>Loading</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('отключается при disabled', () => {
+      render(<Button disabled>Disabled</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+    });
+  });
+
+  describe('Взаимодействие', () => {
+    it('вызывает onClick при клике', async () => {
+      const handleClick = jest.fn();
+      render(<Button onClick={handleClick}>Click</Button>);
+
+      const button = screen.getByRole('button');
+      await userEvent.click(button);
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Checkbox from '../Checkbox';
+
+describe('Checkbox Component', () => {
+  describe('Рендеринг', () => {
+    it('рендерит checkbox с label', () => {
+      render(<Checkbox label="Accept terms" />);
+      expect(screen.getByLabelText('Accept terms')).toBeInTheDocument();
+    });
+
+    it('применяет размер через elementSize', () => {
+      const { container } = render(<Checkbox elementSize="small" />);
+      const checkbox = container.querySelector('.small');
+      expect(checkbox).toBeInTheDocument();
+    });
+  });
+
+  describe('Состояния', () => {
+    it('применяет aria-invalid при error', () => {
+      render(<Checkbox error />);
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('отключается при disabled', () => {
+      render(<Checkbox disabled />);
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeDisabled();
+    });
+  });
+
+  describe('Взаимодействие', () => {
+    it('можно отметить галочкой', async () => {
+      render(<Checkbox />);
+      const checkbox = screen.getByRole('checkbox');
+
+      await userEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
+    });
+  });
+});

--- a/src/components/Input/__tests__/Input.test.tsx
+++ b/src/components/Input/__tests__/Input.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import Input from '../Input';
+
+describe('Input Component', () => {
+  describe('Рендеринг', () => {
+    it('рендерит input с label', () => {
+      render(<Input label="Email" />);
+      expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    });
+
+    it('использует переданный type', () => {
+      render(<Input type="email" />);
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveAttribute('type', 'email');
+    });
+
+    it('применяет размер через elementSize', () => {
+      const { container } = render(<Input elementSize="large" />);
+      const input = container.querySelector('.large');
+      expect(input).toBeInTheDocument();
+    });
+  });
+
+  describe('Валидация', () => {
+    it('отображает сообщение об ошибке', () => {
+      render(<Input error="Invalid email" />);
+      expect(screen.getByText('Invalid email')).toBeInTheDocument();
+    });
+
+    it('применяет aria-invalid при ошибке', () => {
+      render(<Input error="Error" />);
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+});

--- a/src/components/Radio/__tests__/Radio.test.tsx
+++ b/src/components/Radio/__tests__/Radio.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Radio from '../Radio';
+
+describe('Radio Component', () => {
+  describe('Рендеринг', () => {
+    it('рендерит radio с label', () => {
+      render(<Radio label="Option A" />);
+      expect(screen.getByLabelText('Option A')).toBeInTheDocument();
+    });
+
+    it('применяет размер через elementSize', () => {
+      const { container } = render(<Radio elementSize="large" />);
+      const radio = container.querySelector('.large');
+      expect(radio).toBeInTheDocument();
+    });
+  });
+
+  describe('Состояния', () => {
+    it('применяет aria-invalid при error', () => {
+      render(<Radio error />);
+      const radio = screen.getByRole('radio');
+      expect(radio).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('отключается при disabled', () => {
+      render(<Radio disabled />);
+      const radio = screen.getByRole('radio');
+      expect(radio).toBeDisabled();
+    });
+  });
+
+  describe('Взаимодействие', () => {
+    it('можно выбрать', async () => {
+      render(<Radio />);
+      const radio = screen.getByRole('radio');
+
+      await userEvent.click(radio);
+      expect(radio).toBeChecked();
+    });
+  });
+});

--- a/src/components/Select/__tests__/Select.test.tsx
+++ b/src/components/Select/__tests__/Select.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Select from '../Select';
+
+const mockOptions = [
+  { value: '1', label: 'Option 1' },
+  { value: '2', label: 'Option 2' },
+  { value: '3', label: 'Option 3' },
+];
+
+describe('Select Component', () => {
+  describe('Рендеринг', () => {
+    it('рендерит select с label', () => {
+      render(<Select label="Choose option" options={mockOptions} />);
+      expect(screen.getByText('Choose option')).toBeInTheDocument();
+    });
+
+    it('отображает placeholder', () => {
+      render(<Select options={mockOptions} placeholder="Select..." />);
+      expect(screen.getByText('Select...')).toBeInTheDocument();
+    });
+
+    it('применяет размер через elementSize', () => {
+      const { container } = render(<Select options={mockOptions} elementSize="small" />);
+      const select = container.querySelector('.small');
+      expect(select).toBeInTheDocument();
+    });
+  });
+
+  describe('Взаимодействие', () => {
+    it('открывает dropdown при клике', async () => {
+      render(<Select options={mockOptions} />);
+      const combobox = screen.getByRole('combobox');
+
+      await userEvent.click(combobox);
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    it('выбирает опцию', async () => {
+      const handleChange = jest.fn();
+      render(<Select options={mockOptions} onChange={handleChange} />);
+
+      const combobox = screen.getByRole('combobox');
+      await userEvent.click(combobox);
+
+      const option = screen.getByText('Option 2');
+      await userEvent.click(option);
+
+      expect(handleChange).toHaveBeenCalledWith('2');
+    });
+  });
+});

--- a/src/components/Text/__tests__/Text.test.tsx
+++ b/src/components/Text/__tests__/Text.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import Text from '../Text';
+
+describe('Text Component', () => {
+  describe('Рендеринг', () => {
+    it('рендерит текст', () => {
+      render(<Text>Hello World</Text>);
+      expect(screen.getByText('Hello World')).toBeInTheDocument();
+    });
+
+    it('использует переданный тег', () => {
+      render(<Text tag="h1">Heading</Text>);
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+  });
+
+  describe('Стили', () => {
+    it('применяет класс muted', () => {
+      const { container } = render(<Text muted>Muted text</Text>);
+      const element = container.querySelector('.muted');
+      expect(element).toBeInTheDocument();
+    });
+
+    it('применяет класс bold', () => {
+      const { container } = render(<Text bold>Bold text</Text>);
+      const element = container.querySelector('.bold');
+      expect(element).toBeInTheDocument();
+    });
+
+    it('применяет класс error', () => {
+      const { container } = render(<Text error>Error text</Text>);
+      const element = container.querySelector('.error');
+      expect(element).toBeInTheDocument();
+    });
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "module": "commonjs",
+    "verbatimModuleSyntax": false
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/setupTests.ts"
+  ]
+}


### PR DESCRIPTION
# Базовые компоненты. Тесты

## Описание

Реализованы тесты для всех UI-компонентов проекта. Покрыто тестами 6 компонентов с проверкой рендеринга, состояний, стилей и пользовательского взаимодействия.

## Что сделано

### Настройка тестового окружения

- Создан `tsconfig.test.json` с конфигурацией TypeScript для тестов:
  - `jsx: "react-jsx"` — поддержка JSX в тестах
  - `esModuleInterop: true` — корректная работа импортов
  - `module: "commonjs"` — совместимость с Jest
  - `verbatimModuleSyntax: false` — отключение строгого синтаксиса модулей

- Обновлен `jest.config.cjs`:
  - Добавлена ссылка на `tsconfig.test.json` в секции `transform`

### Написанные тесты (31 тест)

#### **Checkbox** (5 тестов)

- **Рендеринг**: проверка отображения с label, применение размера через `elementSize`
- **Состояния**: `aria-invalid` при ошибке, `disabled` состояние
- **Взаимодействие**: возможность отметить галочкой

#### **Text** (5 тестов)

- **Рендеринг**: отображение текста, использование переданного тега (h1, p, span)
- **Стили**: применение классов `muted`, `bold`, `error`

#### **Input** (5 тестов)

- **Рендеринг**: отображение с label, использование переданного type, размер через `elementSize`
- **Валидация**: отображение сообщения об ошибке, `aria-invalid` при ошибке

#### **Radio** (5 тестов)

- **Рендеринг**: отображение с label, применение размера через `elementSize`
- **Состояния**: `aria-invalid` при ошибке, `disabled` состояние
- **Взаимодействие**: возможность выбрать опцию

#### **Button** (6 тестов)

- **Рендеринг**: отображение текста кнопки, применение `variant` и `size` классов
- **Состояния**: `disabled` при `loading`, `disabled` состояние
- **Взаимодействие**: вызов `onClick` при клике

#### **Select** (5 тестов)

- **Рендеринг**: отображение с label, placeholder, размер через `elementSize`
- **Взаимодействие**: открытие dropdown при клике, выбор опции с вызовом `onChange`

<img width="447" height="605" alt="image" src="https://github.com/user-attachments/assets/cf51acf6-74fe-46c4-b66c-9c4078da669e" />
<img width="479" height="609" alt="image" src="https://github.com/user-attachments/assets/dfec0666-0cf1-4840-bc2c-a14aaf6d9eda" />

