### PR TITLE
Авторизация/Регистрация. Разграничение доступов

### DIFF
--- a/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { observer } from 'mobx-react-lite';
+import { authStore } from 'store/AuthStore';
+import { routes } from 'config/routes';
+
+export type PrivateRouteProps = {
+  children: React.ReactNode;
+  inverted?: boolean;
+  redirectTo?: string;
+};
+
+const PrivateRoute: React.FC<PrivateRouteProps> = observer(
+  ({ children, inverted = false, redirectTo }) => {
+    const location = useLocation();
+    const isAuthenticated = authStore.isAuthenticated;
+
+    const allowed = inverted ? !isAuthenticated : isAuthenticated;
+
+    if (!allowed) {
+      const defaultRedirect = inverted ? routes.profile.create() : routes.auth.create.login();
+
+      return <Navigate to={redirectTo || defaultRedirect} state={{ from: location }} replace />;
+    }
+
+    return <>{children}</>;
+  },
+);
+
+export default PrivateRoute;

--- a/src/components/PrivateRoute/index.ts
+++ b/src/components/PrivateRoute/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PrivateRoute';
+export * from './PrivateRoute';

--- a/src/config/routesConfig.tsx
+++ b/src/config/routesConfig.tsx
@@ -7,6 +7,7 @@ import LoginForm from 'pages/Auth/components/LoginForm';
 import RegisterForm from 'pages/Auth/components/RegisterForm';
 import Demo from 'pages/Demo';
 import Main from 'pages/Main';
+import PrivateRoute from 'components/PrivateRoute';
 
 export const routesConfig: RouteObject[] = [
   {
@@ -16,11 +17,19 @@ export const routesConfig: RouteObject[] = [
     children: [
       {
         path: routes.main.mask,
-        element: <Main />,
+        element: (
+          <PrivateRoute>
+            <Main />
+          </PrivateRoute>
+        ),
       },
       {
         path: routes.profile.mask,
-        element: <>Профиль пользователя</>,
+        element: (
+          <PrivateRoute>
+            <>Профиль пользователя</>
+          </PrivateRoute>
+        ),
       },
       {
         path: routes.about.mask,
@@ -28,7 +37,11 @@ export const routesConfig: RouteObject[] = [
       },
       {
         path: routes.auth.mask,
-        element: <Auth />,
+        element: (
+          <PrivateRoute inverted>
+            <Auth />
+          </PrivateRoute>
+        ),
         children: [
           {
             index: true,


### PR DESCRIPTION
### Issue: https://github.com/Blshop/JS-Practice-Hub/issues/49

#### Создан компонент PrivateRoute (`src/components/PrivateRoute/PrivateRoute.tsx`):
- Принимает пропсы `children` (защищаемая страница), `inverted` (по умолчанию `false` = для авторизованных) и опциональный `redirectTo` (куда редиректим, если (не) авторизован)
- Использует observer из для реактивности на `authStore.isAuthenticated`
- При несоответствии условия выполняет редирект:
    - Для обычного режима (`inverted=false`) - на `/auth/login` (с сохранением исходного пути в state)
    - Для инвертированного режима (`inverted=true`) — на `/profile` (или кастомный путь)

#### Обновлена конфигурация маршрутов (`src/config/routesConfig.tsx`):
- `Main` и `Profile` обернуты в `PrivateRoute` (доступны только авторизованным)
- `About` и `Demo` оставлены открытыми для всех
- Маршрут авторизации (`/auth/*`) обёрнут в `PrivateRoute` с `inverted` - доступен только неавторизованным

#### Демонстрация работы:
https://github.com/user-attachments/assets/562f571a-06b2-4f39-81e1-d21e18aff7ee


