### PR TITLE
fix: add missing text component import in question renderer

### DIFF
--- a/src/pages/Quiz/renderers/QuestionRenderer/QuestionRenderer.tsx
+++ b/src/pages/Quiz/renderers/QuestionRenderer/QuestionRenderer.tsx
@@ -5,6 +5,7 @@ import SingleCorrectRenderer from '../SingleCorrectRenderer';
 import MultipleCorrectRenderer from '../MultipleCorrectRenderer';
 import YesNoRenderer from '../YesNoRenderer';
 import PredictOutputRenderer from '../PredictOutputRenderer';
+import Text from 'components/Text';
 
 interface Props {
   question: Question;
@@ -56,7 +57,11 @@ const QuestionRenderer: React.FC<Props> = ({ question, userAnswer, isChecked, on
       );
 
     default:
-      return <Text tag='div' error>Unsupported question type</Text>;
+      return (
+        <Text tag="div" error>
+          Unsupported question type
+        </Text>
+      );
   }
 };
 


### PR DESCRIPTION
## Исправление ошибок сборки

Исправлены ошибки TypeScript в `QuestionRenderer`:

- Добавлен недостающий импорт компонента `Text`

Сборка проходит успешно ✓
