### PR TITLE
refactor: move authentication logic from app to header component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import 'styles/styles.css';
 import styles from './App.module.scss';
 import Footer from 'components/Footer';
 import Header from 'components/Header';
-import { authStore } from 'store/AuthStore';
 
 interface RouteHandle {
   hideHeaderFooter: boolean;
@@ -21,21 +20,19 @@ const App = observer(() => {
     (match) => (match.handle as RouteHandle | undefined)?.hideHeaderFooter,
   );
 
-  const showHeaderFooter = authStore.isAuthenticated && !hideHeaderFooter;
-
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [location]);
 
   return (
     <div className={styles.app}>
-      {showHeaderFooter && <Header />}
+      {!hideHeaderFooter && <Header />}
 
       <main className={styles.app__main}>
         <Outlet />
       </main>
 
-      {showHeaderFooter && <Footer />}
+      {!hideHeaderFooter && <Footer />}
 
       <ToastContainer
         position="top-right"

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -74,25 +74,25 @@ export const Header: React.FC = observer(() => {
         role="navigation"
         aria-label="Main navigation"
       >
-        {NAV_ITEMS.map((item) => {
-          const isActive = location.pathname === item.path;
-          return (
-            <Button
-              key={item.label}
-              variant="secondary"
-              onClick={() => handleNavigation(item.path)}
-              className={classNames(styles.header__link, styles.button)}
-              aria-current={isActive ? 'page' : undefined}
-            >
-              <Text uppercase bold>
-                {item.label}
-              </Text>
-            </Button>
-          );
-        })}
-
         {authStore.isAuthenticated && (
           <>
+            {NAV_ITEMS.map((item) => {
+              const isActive = location.pathname === item.path;
+              return (
+                <Button
+                  key={item.label}
+                  variant="secondary"
+                  onClick={() => handleNavigation(item.path)}
+                  className={classNames(styles.header__link, styles.button)}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  <Text uppercase bold>
+                    {item.label}
+                  </Text>
+                </Button>
+              );
+            })}
+
             <Button
               variant="danger"
               onClick={handleLogout}
@@ -100,8 +100,18 @@ export const Header: React.FC = observer(() => {
             >
               <Text bold>Logout</Text>
             </Button>
+
             <Badge variant="info">🙂 {authStore.user?.username}</Badge>
           </>
+        )}
+
+        {!authStore.isAuthenticated && (
+          <Button
+            onClick={() => handleNavigation(routes.auth.mask)}
+            className={classNames(styles.header__link, styles.button)}
+          >
+            <Text bold>Login</Text>
+          </Button>
         )}
       </nav>
 

--- a/src/config/routesConfig.tsx
+++ b/src/config/routesConfig.tsx
@@ -39,6 +39,7 @@ export const routesConfig: RouteObject[] = [
       },
       {
         path: routes.auth.mask,
+        handle: { hideHeaderFooter: true },
         element: (
           <PrivateRoute inverted>
             <Auth />

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import learningPathData from 'data/js-learning-path-data.json';
 import userLessonsProgress from 'data/mock-user-lessons-progress.json';
 import {
@@ -16,7 +16,6 @@ const Main: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [userProgress, setUserProgress] = useState<UserProgress | null>(null);
-  const isFirstLoadRef = useRef(true);
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -25,17 +24,9 @@ const Main: React.FC = () => {
     try {
       // TODO: Заменить на реальный API запрос
       // 1. Удалить строку ниже (имитация задержки):
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      // 2. Удалить блок имитации ошибки (строки ниже до setUserProgress):
-      // Первая загрузка всегда с ошибкой, последующие - успешные
-      if (isFirstLoadRef.current) {
-        isFirstLoadRef.current = false;
-        throw new Error('Failed to load learning path data. Please try again.');
-      }
-      // 3. Удалить isFirstLoadRef из компонента (объявление и useRef импорт если больше не используется)
-
-      // 4. Заменить строку ниже на реальный запрос:
+      // 2. Заменить строку ниже на реальный запрос:
       // const response = await fetch('/api/user/progress');
       // const data = await response.json();
       // setUserProgress(data);


### PR DESCRIPTION
# PR: Рефакторинг проверки авторизации в Header и Footer (#102)

## Описание изменений

Перенесена логика проверки авторизации из `App.tsx` в компонент `Header.tsx`. Теперь компоненты самостоятельно управляют своим отображением в зависимости от статуса авторизации пользователя.

## Что изменено

### App.tsx

- Удален импорт `authStore`
- Удалена переменная `showHeaderFooter`
- Упрощено условие отображения Header и Footer: `{!hideHeaderFooter && <Header />}`

### Header.tsx

- Навигационное меню перенесено внутрь блока `{authStore.isAuthenticated && (...)}`
- Добавлен блок для неавторизованных пользователей с кнопкой Login
- Компонент теперь отображает:
  - Для авторизованных: меню навигации + кнопка Logout + Badge с именем
  - Для неавторизованных: кнопка Login

### Footer.tsx

- Без изменений (остается видимым всегда)

## Скриншоты

<img width="1897" height="910" alt="image" src="https://github.com/user-attachments/assets/72f59242-8783-44a7-8d9c-19a5342b1b99" />

<img width="1898" height="909" alt="image" src="https://github.com/user-attachments/assets/a1f1490b-85ce-4cc4-9ef4-d14788e35fa4" />

